### PR TITLE
Allow new line after message

### DIFF
--- a/lib/grammar/grammar.pegjs
+++ b/lib/grammar/grammar.pegjs
@@ -1,6 +1,6 @@
 { const { _ }	= options }
 CommitMessage
-	= title:Title Newline? message:Message? {
+	= title:Title Newline? message:Message? Newline? {
 		if (!message) {
 			return {
 				prefix: title.prefix,
@@ -35,8 +35,8 @@ Title
 		};
 	}
 
-Newline "newline between title and body"
-	= '\n' / '\r\n'
+Newline "newline"
+	= '\n' / '\r\n' / '\r'
 
 Message "body and footers"
 	= body:Body? footers:Footers? {


### PR DESCRIPTION
Allow new line after message and \r type lines

Change-type: patch
Signed-off-by: Stathis Moraitidis <stathis@balena.io>